### PR TITLE
Fixes Issue #11

### DIFF
--- a/darkmode.less
+++ b/darkmode.less
@@ -43,6 +43,8 @@
 	
 	// General
 	.arrow {
+        width: 20px !important;
+        height: 16px !important;
 	    background-image: url(%%arrows-bot-dark%%) !important;
 		
 		&::after {
@@ -185,6 +187,27 @@
 			background: none;
 		}
 	}
+    
+    // fixes the arrows from RES from showing up issue #11
+    .arrow.up, .arrow.up:hover, .arrow.down, .arrow.down:hover {
+        background-image: url(%%arrows-bot-dark%%) !important;
+    }
+    
+    .arrow.up {
+        background-position: 0px 0px !important;
+        
+        &:hover {
+            background-position: -20px 0px!important;
+        }
+    }
+    
+    .arrow.down {
+        background-position: 0px -16px !important;
+        
+        &:hover {
+            background-position: -20px -16px !important
+        }
+    }    
 }
 
 // Importants applied:

--- a/darkmode.less
+++ b/darkmode.less
@@ -45,6 +45,7 @@
 	.arrow {
         width: 20px !important;
         height: 16px !important;
+        margin-top: 2px;
 	    background-image: url(%%arrows-bot-dark%%) !important;
 		
 		&::after {

--- a/res-fixes.less
+++ b/res-fixes.less
@@ -27,9 +27,4 @@ html.res-commentBoxes body > .content {
 	margin-bottom: -@content-padding;
 }
 
-// fixes the arrows from RES from showing up issue #11
-.res-nightmode .arrow.up:hover, .res-nightmode .arrow.up,
-.res-nightmode .arrow.down, .res-nightmode .arrow.down:hover {
-    background: none !important;
-}
 

--- a/res-fixes.less
+++ b/res-fixes.less
@@ -26,3 +26,10 @@ html.res-commentBoxes body > .content {
 	width: 100%;
 	margin-bottom: -@content-padding;
 }
+
+// fixes the arrows from RES from showing up issue #11
+.res-nightmode .arrow.up:hover, .res-nightmode .arrow.up,
+.res-nightmode .arrow.down, .res-nightmode .arrow.down:hover {
+    background: none !important;
+}
+


### PR DESCRIPTION
Res nightmode shows its own up and down arrows. The styles added should
remove them. This is the first time contributing, so please let me know if I am doing anything wrong. Thanks

Here is the result from chrome:

![league-css-issue-11](https://cloud.githubusercontent.com/assets/13503593/10238247/f81dd67a-6871-11e5-8bfd-3d50c3a6d8b5.PNG)
