### PR TITLE
Fix Issue #19

### DIFF
--- a/sidebar.less
+++ b/sidebar.less
@@ -642,6 +642,8 @@
 	
 	.title {
 		text-align: center;
+		position: absolute;
+		width: @side-width - @content-padding-total - 15px;
 		
 		h1 {
 			display: inline-block;
@@ -659,11 +661,8 @@
 	
 	// Large mod message button
 	a.helplink {
-		display: block;
 		width: @side-width - @content-padding-total - 15px;
-		position: absolute;
-		float: none;
-		
+		margin-bottom: 10px;
 		margin-top: 24px;
 		padding: 6px 0;
 		
@@ -674,10 +673,6 @@
 		
 		&:hover {
 			.side-fancy-button-hover-bg();
-		}
-		
-		& + .title + .content {
-			padding-top: 52px;
 		}
 	}
 }


### PR DESCRIPTION
Make the title for the sidebar to position absolute instead since it
will not be changing in height. Keep the Message a Moderator button
floating right with the same width so it will be below the Moderato
title. The content should then stay on the bottom of the button now no
matter the height.
