### PR TITLE
Small fixes for RES upcoming changes, zero impact otherwise

### DIFF
--- a/sidebar.less
+++ b/sidebar.less
@@ -191,7 +191,7 @@
 	}
 	
 	.subscribe-button a.active,					// Normal subscribe button
-	.subButtons span:not(.subscribe-button) {	// RES subscribe buttons (+shortcut, +dashboard)
+	.subButtons > span:not(.subscribe-button) {	// RES subscribe buttons (+shortcut, +dashboard)
 		display: inline-block;
 		width: 83px;
 		line-height: 21px;
@@ -206,6 +206,10 @@
 		&:hover {
 			.side-fancy-button-hover-bg();
 		}
+	}
+	
+	.subButtons .multi-count {
+		display: none;
 	}
 	
 	.subButtons :last-child {


### PR DESCRIPTION
The current source build adds a "multi-count" counter (counts how many multi's the subreddit is in) as a span inside the subscriber button span. So updating the `.subButtons span:not(.subscribe-button)` to `.subButtons > span:not(.subscribe-button)` should address any future issues of nested spans becoming buttons while also just hiding the "multi-count" all together since it's fairly useless anyways.